### PR TITLE
[FIX] Refactor error handling in GaiaScreenHandler to comment out net…

### DIFF
--- a/chrome/browser/ui/webui/ash/login/gaia_screen_handler.cc
+++ b/chrome/browser/ui/webui/ash/login/gaia_screen_handler.cc
@@ -1605,6 +1605,7 @@ void GaiaScreenHandler::UpdateStateInternal(NetworkError::ErrorReason reason,
   }
 
   if (!is_online || is_gaia_loading_timeout || is_gaia_error) {
+    // ---***JEMAOS BEGIN***---
     // BUGFIX: https://github.com/JemaOS/project-jemaos/issues/10
     // if (GetCurrentScreen() != ErrorScreenView::kScreenId) {
     //   error_screen_->SetParentScreen(GaiaView::kScreenId);
@@ -1613,6 +1614,7 @@ void GaiaScreenHandler::UpdateStateInternal(NetworkError::ErrorReason reason,
     // }
     // // Show `ErrorScreen` or update network error message.
     // error_screen_->ShowNetworkErrorMessage(state, reason);
+    // ---***JEMAOS END***---
     histogram_helper_->OnErrorShow(error_screen_->GetErrorState());
   } else {
     HideOfflineMessage(state, reason);

--- a/chrome/browser/ui/webui/ash/login/gaia_screen_handler.cc
+++ b/chrome/browser/ui/webui/ash/login/gaia_screen_handler.cc
@@ -1605,13 +1605,14 @@ void GaiaScreenHandler::UpdateStateInternal(NetworkError::ErrorReason reason,
   }
 
   if (!is_online || is_gaia_loading_timeout || is_gaia_error) {
-    if (GetCurrentScreen() != ErrorScreenView::kScreenId) {
-      error_screen_->SetParentScreen(GaiaView::kScreenId);
-      error_screen_->SetHideCallback(base::BindOnce(
-          &GaiaScreenHandler::OnErrorScreenHide, weak_factory_.GetWeakPtr()));
-    }
-    // Show `ErrorScreen` or update network error message.
-    error_screen_->ShowNetworkErrorMessage(state, reason);
+    // BUGFIX: https://github.com/JemaOS/project-jemaos/issues/10
+    // if (GetCurrentScreen() != ErrorScreenView::kScreenId) {
+    //   error_screen_->SetParentScreen(GaiaView::kScreenId);
+    //   error_screen_->SetHideCallback(base::BindOnce(
+    //       &GaiaScreenHandler::OnErrorScreenHide, weak_factory_.GetWeakPtr()));
+    // }
+    // // Show `ErrorScreen` or update network error message.
+    // error_screen_->ShowNetworkErrorMessage(state, reason);
     histogram_helper_->OnErrorShow(error_screen_->GetErrorState());
   } else {
     HideOfflineMessage(state, reason);


### PR DESCRIPTION
Commented out the below code. to stop loop on login web page fails. Now we will show the error instead of looping.
```
if (GetCurrentScreen() != ErrorScreenView::kScreenId) {
  error_screen_->SetParentScreen(GaiaView::kScreenId);
  error_screen_->SetHideCallback(base::BindOnce(
      &GaiaScreenHandler::OnErrorScreenHide, weak_factory_.GetWeakPtr()));
}
// Show `ErrorScreen` or update network error message.
error_screen_->ShowNetworkErrorMessage(state, reason);
```