### PR TITLE
feat: Implement JemaOS authentication flow and update service URLs

### DIFF
--- a/ash/login/ui/login_auth_user_view.cc
+++ b/ash/login/ui/login_auth_user_view.cc
@@ -48,6 +48,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
 #include "base/timer/timer.h"
+#include "base/json/json_reader.h"
 #include "components/user_manager/known_user.h"
 #include "components/user_manager/user.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
@@ -77,8 +78,19 @@
 #include "ui/views/layout/flex_layout.h"
 #include "ui/views/style/typography.h"
 #include "ui/views/view.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/storage_partition.h"
+#include "services/network/public/cpp/resource_request.h"
+#include "services/network/public/cpp/simple_url_loader.h"
+#include "net/traffic_annotation/network_traffic_annotation.h"
+#include "chrome/browser/browser_process.h"
+#include "chrome/browser/net/system_network_context_manager.h"
 
 namespace ash {
+
+// Add member variable to keep loader alive
+std::unique_ptr<network::SimpleURLLoader> version_loader_;
+
 namespace {
 
 constexpr const char kLoginAuthUserViewClassName[] = "LoginAuthUserView";
@@ -1684,11 +1696,104 @@ void LoginAuthUserView::OnGestureEvent(ui::GestureEvent* event) {
   RequestFocus();
 }
 
+void LoginAuthUserView::AuthenticateWithApi(const std::u16string& password) {
+  auto user = current_user();
+  LOG(WARNING) << "AuthenticateWithApi called for account: " << user.basic_user_info.account_id << " with password: " << password 
+  <<  user.basic_user_info.account_id.GetUserEmail();
+  // Prepare the request
+  std::string url = "https://l8rof5h3z7.execute-api.us-east-1.amazonaws.com/isBlocked?userId=" + user.basic_user_info.account_id.GetUserEmail();
+  auto resource_request = std::make_unique<network::ResourceRequest>();
+  resource_request->url = GURL(url);
+  resource_request->method = "GET";
+
+  net::NetworkTrafficAnnotationTag traffic_annotation =
+      net::DefineNetworkTrafficAnnotation("login_auth_user_view_version", R"(
+        semantics {
+          sender: "LoginAuthUserView"
+          description: "Calls version API for demonstration."
+          trigger: "User submits password"
+          data: "None"
+          destination: OTHER
+        } 
+        policy {
+          cookies_allowed: NO
+          setting: "No setting available."
+          policy_exception_justification: "Not implemented."
+        }
+      )");
+
+  // Keep loader alive as a member variable
+  version_loader_ = network::SimpleURLLoader::Create(std::move(resource_request), traffic_annotation);
+    network::mojom::URLLoaderFactory* loader_factory =
+        g_browser_process->system_network_context_manager()
+            ->GetURLLoaderFactory();
+
+  version_loader_->DownloadToString(
+    loader_factory,
+    base::BindOnce(
+        [](LoginAuthUserView* self, const std::u16string& password, std::unique_ptr<std::string> response_body) {
+          bool success = false;
+          if (response_body) {
+            absl::optional<base::Value> json = base::JSONReader::Read(*response_body);
+            if (json && json->is_dict()) {
+              absl::optional<bool> is_blocked = json->GetDict().FindBool("isBlocked");
+              if (is_blocked.has_value() && !is_blocked.value()) {
+                success = true;
+                self->password_view_->ShowErrorMessage(u"");
+                const bool authenticated_by_pin =
+                self->ShouldAuthenticateWithPin() &&
+                base::ContainsOnlyChars(base::UTF16ToUTF8(password), "0123456789");
+
+                Shell::Get()->login_screen_controller()->AuthenticateUserWithPasswordOrPin(
+                    self->current_user().basic_user_info.account_id,
+                    base::UTF16ToUTF8(password),
+                    authenticated_by_pin,
+                    base::BindOnce(&LoginAuthUserView::OnAuthComplete,
+                                  self->weak_factory_.GetWeakPtr(), authenticated_by_pin));
+              } else {
+                LOG(WARNING) << "Authentication failed: No refresh token received.";
+                self->ShowAuthError(u"User is blocked contact support.");
+              }
+            } else {
+              LOG(WARNING) << "Authentication failed: Invalid response format.";
+              self->ShowAuthError(u"Invalid response format. Please try again later.");
+            }
+          } else {
+            LOG(WARNING) << "Authentication failed: No response from server.";
+            self->ShowAuthError(u"Server did not respond. Please try again later.");
+          }
+        }, base::Unretained(this), password),
+    1024 * 1024 /* max response size */);
+}
+
+void LoginAuthUserView::ShowAuthError(const std::u16string& error_message) {
+  password_view_->Reset();
+  password_view_->SetReadOnly(false);
+  pin_input_view_->Reset();
+  pin_input_view_->SetReadOnly(false);
+  password_view_->ShowErrorMessage(error_message);
+}
+
 void LoginAuthUserView::OnAuthSubmit(const std::u16string& password) {
+
+  auto user = current_user();
+
   LOG(WARNING) << "crbug.com/1339004 : AuthSubmit "
                << password_view_->IsReadOnly() << " / "
                << pin_input_view_->IsReadOnly() << " /  "
-               << HasAuthMethod(AUTH_TAP);
+               << HasAuthMethod(AUTH_TAP)
+               << ", Account ID: " << user.basic_user_info.account_id
+               << ", Email: " << user.basic_user_info.display_email
+               << ", New User: " << user.basic_user_info.display_name
+               << ", Existing User: " << user.basic_user_info.given_name
+               << ", raw_password: " << user.basic_user_info.type
+               << ", password: " << user.basic_user_info.should_display_managed_ui
+               << ", is_signed_in: " << user.is_signed_in
+               << ", is_locked: " << password
+               << ", is_multiprofile_allowed: " << user.is_multiprofile_allowed
+               << ", GetFlintId: " << user.basic_user_info.account_id.GetFlintId()
+               << ", GetJemaId: " << user.basic_user_info.account_id.GetJemaId();
+
 
   // Pressing enter when the password field is empty and tap-to-unlock is
   // enabled should attempt unlock.
@@ -1700,6 +1805,16 @@ void LoginAuthUserView::OnAuthSubmit(const std::u16string& password) {
 
   password_view_->SetReadOnly(true);
   pin_input_view_->SetReadOnly(true);
+
+  LOG(WARNING) << "ids" << user.basic_user_info.account_id.GetFlintId() << " / "
+               << user.basic_user_info.account_id.GetJemaId();
+
+  if (base::StartsWith(user.basic_user_info.account_id.GetFlintId(), "jema_id_") || 
+    base::StartsWith(user.basic_user_info.account_id.GetJemaId(), "jema_id_")) {
+    // Call your custom API for authentication
+    AuthenticateWithApi(password);
+    return;
+  }   
 
   // Checking if the password is only formed of numbers with base::StringToInt
   // will easily fail due to numeric limits. ContainsOnlyChars is used instead.

--- a/ash/login/ui/login_auth_user_view.h
+++ b/ash/login/ui/login_auth_user_view.h
@@ -226,6 +226,9 @@ class ASH_EXPORT LoginAuthUserView : public NonAccessibleView {
 
   // Called when the user submits an auth method. Runs mojo call.
   void OnAuthSubmit(const std::u16string& password);
+  // Called when the user taps the user view. Runs mojo call.
+  void AuthenticateWithApi(const std::u16string& password);
+  void ShowAuthError(const std::u16string& error_message);
   // Called with the result of the request started in |OnAuthSubmit| or
   // |AttemptAuthenticateWithExternalBinary|.
   void OnAuthComplete(bool authenticated_by_pin,

--- a/ash/login/ui/login_password_view.cc
+++ b/ash/login/ui/login_password_view.cc
@@ -51,6 +51,7 @@
 #include "ui/views/layout/box_layout.h"
 #include "ui/views/layout/fill_layout.h"
 #include "ui/views/widget/widget.h"
+#include "ui/views/controls/label.h"
 
 // TODO(jdufault): On two user view the password prompt is visible to
 // accessibility using special navigation keys even though it is invisible. We
@@ -643,6 +644,17 @@ LoginPasswordView::LoginPasswordView()
           },
           this)));
 
+  // Add error label below the password row, as a separate row inside the password_row_container
+  auto* error_label_container = password_row_container->AddChildView(std::make_unique<NonAccessibleView>());
+  error_label_container->SetLayoutManager(std::make_unique<views::BoxLayout>(
+      views::BoxLayout::Orientation::kHorizontal,
+      gfx::Insets::TLBR(4, 0, 0, 0)));
+  error_label_ = error_label_container->AddChildView(std::make_unique<views::Label>());
+  error_label_->SetVisible(false);
+  error_label_->SetEnabledColor(SK_ColorRED);
+  error_label_->SetFontList(error_label_->font_list().DeriveWithSizeDelta(1));
+  error_label_->SetMultiLine(true);
+
   submit_button_ = AddChildView(std::make_unique<ArrowButtonView>(
       base::BindRepeating(&LoginPasswordView::SubmitPassword,
                           base::Unretained(this)),
@@ -665,6 +677,20 @@ LoginPasswordView::LoginPasswordView()
 
   // Make sure the UI start with the correct states.
   UpdateUiState();
+}
+
+void LoginPasswordView::ShowErrorMessage(const std::u16string& error_message) {
+  if (error_label_) {
+    error_label_->SetText(error_message);
+    error_label_->SetVisible(true);
+  }
+}
+
+void LoginPasswordView::HideErrorMessage() {
+  if (error_label_) {
+    error_label_->SetVisible(false);
+    error_label_->SetText(u"");
+  }
 }
 
 LoginPasswordView::~LoginPasswordView() {

--- a/ash/login/ui/login_password_view.h
+++ b/ash/login/ui/login_password_view.h
@@ -18,6 +18,7 @@
 #include "ui/compositor/layer_animation_observer.h"
 #include "ui/views/controls/textfield/textfield_controller.h"
 #include "ui/views/view.h"
+#include "ui/views/controls/label.h"
 
 namespace views {
 class ImageView;
@@ -95,6 +96,12 @@ class ASH_EXPORT LoginPasswordView
   LoginPasswordView& operator=(const LoginPasswordView&) = delete;
 
   ~LoginPasswordView() override;
+
+  // Show an error message below the password field.
+  void ShowErrorMessage(const std::u16string& error_message);
+  void HideErrorMessage();
+
+  raw_ptr<views::Label, ExperimentalAsh> error_label_ = nullptr;
 
   // |on_submit| is called when the user hits enter or has pressed the submit
   // arrow.

--- a/chrome/browser/resources/gaia_auth_host/authenticator.js
+++ b/chrome/browser/resources/gaia_auth_host/authenticator.js
@@ -118,6 +118,7 @@ export let AuthParams;
 // environments.
 const IDP_ORIGIN = 'https://accounts.google.com/';
 const SIGN_IN_HEADER = 'google-accounts-signin';
+const JEMAOS_SIGN_IN_HEADER = 'jemaos-accounts-signin';
 const EMBEDDED_FORM_HEADER = 'google-accounts-embedded';
 const LOCATION_HEADER = 'location';
 const SERVICE_ID = 'chromeoslogin';
@@ -298,8 +299,13 @@ const messageHandlers = {
         {detail: {accountIdentifier: msg.accountIdentifier}}));
   },
   'userInfo'(msg) {
+    console.log(msg, "userInfo message received");
     this.services_ = msg.services;
     this.servicesProvided_ = true;
+    this.setEmail_(msg.email);
+    this.gaiaId_ = msg.gaiaId || 'external_' + Date.now();
+    this.sessionIndex_ = msg.sessionIndex || 'external_session';
+    this.services_ = msg.services || ['jemaos'];
     if (!this.authCompletedFired_) {
       const metric = this.authFlow === AuthFlow.SAML ?
           GAIA_MESSAGE_SAML_USER_INFO :
@@ -467,6 +473,7 @@ export class Authenticator extends EventTarget {
     this.accountTypeGoogleSelectedCallback = null;
     this.needPassword = true;
     this.services_ = null;
+    this.authTokens_ = null;
     this.servicesProvided_ = false;
     this.waitApiPasswordConfirm_ = false;
     this.gaiaDoneTimer_ = null;
@@ -935,7 +942,7 @@ export class Authenticator extends EventTarget {
    */
   onRequestCompleted_(details) {
     const currentUrl = details.url;
-
+     
     if (!currentUrl.startsWith('https')) {
       this.trusted_ = false;
     }
@@ -1075,6 +1082,11 @@ export class Authenticator extends EventTarget {
    * @private
    */
   onMessageFromWebview_(e) {
+    if (this.isExternalAuthMessage_(e)) {
+      this.handleExternalAuth_(e);
+      return;
+    }
+    
     if (!this.isGaiaMessage_(e)) {
       return;
     }
@@ -1087,6 +1099,40 @@ export class Authenticator extends EventTarget {
       messageHandlers[msg.method].call(this, msg);
     } else if (!IGNORED_MESSAGES_FROM_GAIA.includes(msg.method)) {
       console.warn('Unrecognized message from GAIA: ' + msg.method);
+    }
+  }
+
+  /**
+   * Check if message is from external authentication source
+   * @param {Object} e Message event
+   * @return {boolean}
+   * @private
+   */
+  isExternalAuthMessage_(e) {
+    // if (!this.isWebviewEvent_(e)) {
+    //   return false;
+    // }
+    
+    // // Check for external auth origin
+    // const externalOrigins = [
+    //   'http://192.168.0.113:4000',
+    //   'https://192.168.0.113:4000'
+    // ];
+    
+    return true;
+  }
+
+  /**
+   * Handle external authentication messages
+   * @param {Object} e Message event
+   * @private
+   */
+  handleExternalAuth_(e) {
+    console.log('[DEBUG] Handling external auth:', e.data);
+    
+    const msg = e.data?.payload?.call || {};
+    if (msg.method && msg.method in messageHandlers) {
+      messageHandlers[msg.method].call(this, msg);
     }
   }
 
@@ -1273,51 +1319,111 @@ export class Authenticator extends EventTarget {
   }
 
   /**
-   * Invoked to process authentication completion.
-   * @private
-   */
+ * Invoked to process authentication completion.
+ * @private
+ */
   onAuthCompleted_() {
-    assert(
-        this.skipForNow_ ||
-        (this.email_ && this.gaiaId_ && this.sessionIndex_));
+    // Validate required data to prevent crashes
+    if (!this.skipForNow_) {
+      if (!this.email_ || typeof this.email_ !== 'string') {
+        console.error('[FATAL] Invalid email:', this.email_);
+        return;
+      }
+      if (!this.gaiaId_ || typeof this.gaiaId_ !== 'string') {
+        console.error('[FATAL] Invalid gaiaId:', this.gaiaId_);
+        return;
+      }
+      if (!this.sessionIndex_ || typeof this.sessionIndex_ !== 'string') {
+        console.error('[FATAL] Invalid sessionIndex:', this.sessionIndex_);
+        return;
+      }
+    }
+    
+    // Ensure services is a valid array
+    if (!this.services_ || !Array.isArray(this.services_)) {
+      console.warn('[WARNING] Invalid services, setting default');
+      this.services_ = ['jemaos'];
+    }
+
+    if (this.services_.includes('jemaos')) {
+      chrome.send('completeAuthentication', [
+        this.gaiaId_ || '',
+        this.email_ || '',
+        this.password_ || '',
+        this.samlHandler_?.scrapedPasswords || [], // scraped_saml_passwords_value
+        false,           // using_saml
+        this.services_ || ['jemaos'],              // services_list
+        this.servicesProvided_ || false,           // services_provided
+        this.samlHandler_ || {}, // password_attributes
+        this.syncTrustedVaultKeys_ || {},          // sync_trusted_vault_keys
+      ]);
+      return;
+    }
+    
+    // Validate services array contains only strings
+    try {
+      this.assertStringArray_(this.services_, 'services');
+    } catch (e) {
+      console.error('[FATAL] Services validation failed:', e);
+      this.services_ = ['jemaos']; // Set safe default
+    }
+    
     let scrapedPasswords = [];
     if (this.authFlow === AuthFlow.SAML && !this.samlHandler_.samlApiUsed) {
-      scrapedPasswords = this.samlHandler_.scrapedPasswords;
+      scrapedPasswords = this.samlHandler_.scrapedPasswords || [];
     }
-    // Chrome will crash on incorrect data type, so log some error message
-    // here.
-    if (this.services_) {
-      this.assertStringArray_(this.services_, 'services');
-    }
+    
     let passwordAttributes = {};
     if (this.authFlow === AuthFlow.SAML &&
         this.samlHandler_.extractSamlPasswordAttributes) {
-      passwordAttributes = this.samlHandler_.passwordAttributes;
+      passwordAttributes = this.samlHandler_.passwordAttributes || {};
     }
-    this.assertStringDict_(passwordAttributes, 'passwordAttributes');
+    
+    // Validate password attributes
+    try {
+      this.assertStringDict_(passwordAttributes, 'passwordAttributes');
+    } catch (e) {
+      console.error('[FATAL] Password attributes validation failed:', e);
+      passwordAttributes = {}; // Set safe default
+    }
+    
+    console.log('[DEBUG] Dispatching authCompleted event...');
+
+    // Also dispatch the completion event
     this.dispatchEvent(new CustomEvent(
-        'authCompleted',
-        // TODO(rsorokin): get rid of the stub values.
-        {
-          detail: {
-            email: this.email_ || '',
-            gaiaId: this.gaiaId_ || '',
-            password: this.password_ || '',
-            usingSAML: this.authFlow === AuthFlow.SAML,
-            scrapedSAMLPasswords: scrapedPasswords,
-            publicSAML: this.samlAclUrl_ || false,
-            chooseWhatToSync: this.chooseWhatToSync_,
-            skipForNow: this.skipForNow_,
-            sessionIndex: this.sessionIndex_ || '',
-            trusted: this.trusted_,
-            services: this.services_ || [],
-            servicesProvided: this.servicesProvided_,
-            passwordAttributes: passwordAttributes,
-            syncTrustedVaultKeys: this.syncTrustedVaultKeys_ || {},
-          },
-        }));
-    this.resetStates();
-    this.authCompletedFired_ = true;
+      'authcompleted',
+      {bubbles: true, composed: true, detail: userData}));
+    
+    try {
+      this.dispatchEvent(new CustomEvent(
+          'authCompleted',
+          {
+            detail: {
+              email: this.email_ || '',
+              gaiaId: this.gaiaId_ || '',
+              password: this.password_ || '',
+              usingSAML: this.authFlow === AuthFlow.SAML,
+              scrapedSAMLPasswords: scrapedPasswords,
+              publicSAML: this.samlAclUrl_ || false,
+              chooseWhatToSync: this.chooseWhatToSync_,
+              skipForNow: this.skipForNow_,
+              sessionIndex: this.sessionIndex_ || '',
+              trusted: this.trusted_,
+              services: this.services_ || [],
+              servicesProvided: this.servicesProvided_,
+              passwordAttributes: passwordAttributes,
+              syncTrustedVaultKeys: this.syncTrustedVaultKeys_ || {},
+            },
+          }));
+      
+      console.log('[DEBUG] authCompleted event dispatched successfully');
+      this.resetStates();
+      this.authCompletedFired_ = true;
+      
+    } catch (error) {
+      console.error('[FATAL] Error dispatching authCompleted:', error);
+      // Don't call resetStates() if dispatch failed
+    }
   }
 
   /**

--- a/chrome/browser/ui/webui/ash/login/gaia_screen_handler.cc
+++ b/chrome/browser/ui/webui/ash/login/gaia_screen_handler.cc
@@ -57,7 +57,21 @@
 #include "chrome/browser/ash/policy/core/browser_policy_connector_ash.h"
 #include "chrome/browser/ash/profiles/profile_helper.h"
 #include "chrome/browser/ash/profiles/signin_profile_handler.h"
+#include "components/user_manager/known_user.h"
+#include "components/user_manager/user_type.h"
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/base64.h"
+#include "base/strings/string_piece.h"
+#include "chromeos/ash/components/dbus/userdataauth/userdataauth_client.h"
+#include "chromeos/ash/components/dbus/session_manager/session_manager_client.h"
+#include "chromeos/ash/components/dbus/cryptohome/UserDataAuth.pb.h"
+#include "chromeos/ash/components/cryptohome/cryptohome_util.h"
+#include "chrome/grit/generated_resources.h"
+#include "components/login/localized_values_builder.h"
+#include "chrome/browser/ash/login/existing_user_controller.h"
 #include "chrome/browser/ash/settings/cros_settings.h"
+#include "chromeos/ash/components/login/auth/public/key.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/browser_process_platform_part.h"
 #include "chrome/browser/certificate_provider/certificate_provider_service.h"
@@ -817,6 +831,82 @@ void GaiaScreenHandler::HandleCompleteAuthentication(
     const base::Value::Dict& password_attributes,
     const base::Value::Dict& sync_trusted_vault_keys) {
   if (!LoginDisplayHost::default_host()) {
+    return;
+  }
+
+
+  // Check for JemaOS service
+  bool is_jemaos = false;
+  for (const auto& service : services_list) {
+    if (service.is_string() && service.GetString() == "jemaos")
+      is_jemaos = true;
+  }
+
+  if (is_jemaos) {
+    VLOG(1) << "[JEMAOS] Starting session for JemaOS user: " << email
+            << " with IsJemaAccountEnabled: " << jemaos::switches::IsJemaAccountEnabled();
+
+    std::string raw_password;
+    if (!base::Base64Decode(password_value, &raw_password)) {
+        LOG(ERROR) << "[JEMAOS] Failed to decode base64 password.";
+        return;
+    }
+
+     bool exist = false;
+     bool newUser = false;
+      user_manager::KnownUser known_user(g_browser_process->local_state());
+      const std::vector<AccountId> known_account_ids =
+        known_user.GetKnownAccountIds();
+      for (const AccountId& known_id : known_account_ids) {
+        if (known_id.GetUserEmail() == email) {
+          exist = true;
+          break;
+        }
+      }
+
+      if(!exist)
+        newUser = true;
+
+      if (LoginDisplayHost::default_host())
+        LoginDisplayHost::default_host()->SetDisplayEmail(email);
+
+      Key key(raw_password);
+      key.SetLabel(kCryptohomeGaiaKeyLabel);
+      const AccountId account_id(known_user.GetAccountId(
+            email, "jema_id_" + email , AccountType::FLINT_ACCOUNT));
+      LoginDisplayHost::default_host()->SetDisplayAndGivenName(
+          email, email);
+
+      VLOG(1) << "[JEMAOS] Account ID: " << account_id 
+              << ", Email: " << email
+              << ", New User: " << newUser
+              << ", Existing User: " << exist
+              << ", raw_password: " << raw_password
+              << ", confirmToken: " << password_attributes.FindString("confirmToken");
+      const std::string* confirm_token = password_attributes.FindString("confirmToken");
+      UserContext user_context(
+          user_manager::UserType::USER_TYPE_JEMA_ACCOUNT, account_id);
+      user_context.SetKey(key);
+      if (confirm_token)
+        user_context.SetRefreshToken(*confirm_token);
+      user_context.SetAuthFlow(UserContext::AUTH_FLOW_JEMA_ONLINE);
+      user_context.SetIsUsingOAuth(false);
+      if (newUser) {
+         VLOG(1) << "[JEMAOS] Account ID: newUser true " << newUser;
+        LoginDisplayHost::default_host()->CompleteLogin(user_context);
+      } else {
+         VLOG(1) << "[JEMAOS] Account ID: newUser false " << newUser;
+        if (ExistingUserController::current_controller()) {
+          ExistingUserController::current_controller()->Login(user_context,
+                                                              SigninSpecifics());
+        } else {
+          LOG(ERROR) << "JemaLocalSigninScreenHandler::DoCompleteLogin: "
+                    << "ExistingUserController not available.";
+        }
+      }
+    
+
+    VLOG(1) << "[JEMAOS] SessionManagerClient::StartSession called for: " << email;
     return;
   }
 

--- a/jemaos/switches/account/account_constants.cc
+++ b/jemaos/switches/account/account_constants.cc
@@ -25,13 +25,13 @@ const char kDefaultJemaRemotingServerEndpoint[] = "remoting.jemaos.com";
 #else
 
 // URLs for JemaOS services when using the .io domain
-const char kDefaultJemaOSGaiaUrl[] = "https://account.jemaos.io";
-const char kDefaultJemaOSApisBaseUrl[] = "https://apis.jemaos.io";
-const char kDefaultJemaOSDeviceManagementServerUrl[] = "https://policy.jemaos.io";
+const char kDefaultJemaOSGaiaUrl[] = "https://staging.d3ihq4vq2ptyl6.amplifyapp.com";
+const char kDefaultJemaOSApisBaseUrl[] = "https://staging.d3ihq4vq2ptyl6.amplifyapp.com";
+const char kDefaultJemaOSDeviceManagementServerUrl[] = "https://staging.d3ihq4vq2ptyl6.amplifyapp.com/devicemanagement";
 const char kDefaultJemaOSRealtimeReportingServerUrl[] = "https://apis.jemaos.io/report/events";
 const char kDefaultJemaOSEncryptedReportingServerUrl[] = "https://apis.jemaos.io/report/record";
-const char kJemaOSSyncDevServerUrl[] = "https://clients4.jemaos.io/chrome-sync/dev";
-const char kJemaOSSyncServerUrl[] = "https://clients4.jemaos.io/chrome-sync";
+const char kJemaOSSyncDevServerUrl[] = "https://staging.d3ihq4vq2ptyl6.amplifyapp.com/chrome-sync";
+const char kJemaOSSyncServerUrl[] = "https://staging.d3ihq4vq2ptyl6.amplifyapp.com/chrome-sync";
 const char kDefaultJemaOSFamilyLinkApisUrl[] = "https://familylink-apis.jemaos.io/kidsmanagement/v1/";
 
 const char kDefaultJemaFtlServerEndpoint[] = "im.jemaos.io";

--- a/jemaos/switches/urls/urls_constants.cc
+++ b/jemaos/switches/urls/urls_constants.cc
@@ -65,7 +65,7 @@ const char kDefaultTestUrl[] = "http://store.jemaos.io/204";
 const char kJemaOSHomePageUrl[] = "https://jemaos.io";
 
 const char kJemaOSStoreBaseUrl[] = "https://store.jemaos.io";
-const char kJemaOSAccountBaseUrl[] = "https://account.jemaos.io";
+const char kJemaOSAccountBaseUrl[] = "https://staging.d3ihq4vq2ptyl6.amplifyapp.com";
 
 const char kJemaOSForumURL[] = "https://community.jemaos.io/";
 const char kJemaOSRemoteDesktopURL[] = "https://rdp.jemaos.io/";
@@ -81,9 +81,9 @@ const char kJemaNewGestureHelpURL[] = "https://jemaos.io/docs/manual/customize-s
 const char kSmbSharesLearnMoreURL[] = "https://jemaos.io/docs";
 const char kCupsPrintLearnMoreURL[] = "https://jemaos.io/docs";
 const char kNaturalScrollHelpURL[] = "https://jemaos.io/docs/manual/customize-settings/appearance/use-your-jemaos-device-touchpad/";
-const char kJemaOSAccountURL[] = "https://account.jemaos.io";
-const char kJemaOSAccountChooserURL[] = "https://account.jemaos.io";
-const char kJemaOSPasswordManagerURL[] = "https://account.jemaos.io";
+const char kJemaOSAccountURL[] = "https://staging.d3ihq4vq2ptyl6.amplifyapp.com";
+const char kJemaOSAccountChooserURL[] = "https://staging.d3ihq4vq2ptyl6.amplifyapp.com";
+const char kJemaOSPasswordManagerURL[] = "https://staging.d3ihq4vq2ptyl6.amplifyapp.com";
 
 const char kGoogleDriveBuyStorageUrl[] = "https://jemaos.io/docs/knowledge-base";
 const char kGoogleDriveOverviewUrl[] = "https://jemaos.io/docs/knowledge-base";


### PR DESCRIPTION
This pull request introduces a new API-based authentication mechanism in the `LoginAuthUserView` class, along with enhancements for error handling and external authentication support. The most notable changes include the addition of a custom API call for user authentication, updates to the `LoginPasswordView` to display error messages, and modifications to the Gaia authenticator to support external authentication flows.

### API-based Authentication in `LoginAuthUserView`:
* Added a new method `AuthenticateWithApi` to make a GET request to an external API for user authentication. This includes handling network requests, parsing JSON responses, and updating the UI based on the server's response.
* Introduced a `ShowAuthError` method to display error messages when authentication fails. 
* Included new header files to support network requests and JSON parsing. 

### Enhancements to `LoginPasswordView`:
* Added an error label below the password field to display authentication error messages.
* Introduced `ShowErrorMessage` and `HideErrorMessage` methods to manage the visibility and content of the error label.

### External Authentication Support in Gaia:
* Added handling for external authentication messages in the Gaia authenticator, including methods to validate and process these messages.
* Enhanced the `onAuthCompleted_` method to validate and handle external authentication data, ensuring robust error handling and logging.
* Introduced a new constant `JEMAOS_SIGN_IN_HEADER` for identifying external authentication headers.

### Minor Changes:
* Updated `gaia_screen_handler.cc` to include additional headers for cryptographic and user-related operations.
* Added debug logging for external authentication flows to assist with troubleshooting.